### PR TITLE
Add xor_mask utility and docs update

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,3 +3,30 @@
 pub fn hello() -> &'static str {
     "CloakedCanvas core ready!"
 }
+
+/// XOR every byte in `data` with the given `key`.
+///
+/// This is a simple reversible operation useful as a placeholder
+/// until real encryption is implemented.
+pub fn xor_mask(data: &[u8], key: u8) -> Vec<u8> {
+    data.iter().map(|b| b ^ key).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hello_returns_expected_message() {
+        assert_eq!(hello(), "CloakedCanvas core ready!");
+    }
+
+    #[test]
+    fn xor_mask_roundtrip() {
+        let original = b"hello";
+        let key = 0xAA;
+        let encrypted = xor_mask(original, key);
+        let decrypted = xor_mask(&encrypted, key);
+        assert_eq!(decrypted, original);
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,11 @@
 # CloakedCanvas Architecture
 
-_Stub document describing high-level modules, to be expanded in Sprint 0._
+This project is split into multiple pieces:
+
+- `core/` – Rust library providing cryptographic and core utilities.
+  - Currently includes a `hello()` function and a simple `xor_mask` helper
+    used as a reversible placeholder until real encryption is implemented.
+- `plugin/` – Adobe UXP plugin skeleton for a "Secure Export" panel.
+- `web/` – WebAssembly page for decrypting protected assets.
+
+Additional modules and details will be fleshed out in future sprints.


### PR DESCRIPTION
## Summary
- add `xor_mask` helper with tests in `core`
- document the overall architecture including new helper function

## Testing
- `cargo test --manifest-path core/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68403ce4abd88320a544ecb90f7fae24